### PR TITLE
New test to allow testing an arbitrary liquibase script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<openmrs.version>1.9.0</openmrs.version>
 		<properties.file></properties.file>
 		<mvp.file>mvp/openmrs_concepts_1.6.5_20120525.xml</mvp.file>
+		<script.file></script.file>
 		<db.url>jdbc:mysql://localhost:3306/liquibaserunner?autoReconnect=true</db.url>
 		<db.user>root</db.user>
 		<db.password></db.password>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,7 +18,23 @@
 			<artifactId>openmrs-api</artifactId>
 			<version>${openmrs.version}</version>
 		</dependency>
-	
+
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<version>${openmrs.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.openmrs.test</groupId>
+			<artifactId>openmrs-test</artifactId>
+			<version>${openmrs.version}</version>
+			<type>pom</type>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.openmrs.contrib</groupId>
 			<artifactId>liquibaserunner-liquibase${liquibase.version}</artifactId>

--- a/test/src/test/java/org/openmrs/contrib/liquibaserunner/UpgradeScriptTest.java
+++ b/test/src/test/java/org/openmrs/contrib/liquibaserunner/UpgradeScriptTest.java
@@ -1,0 +1,46 @@
+package org.openmrs.contrib.liquibaserunner;
+
+
+import junit.framework.Assert;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.util.DatabaseUpdateException;
+import org.openmrs.util.DatabaseUpdater;
+import org.openmrs.util.InputRequiredException;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class UpgradeScriptTest extends BaseModuleContextSensitiveTest {
+	@Test
+	public void shouldUpgradeScript() throws SQLException, IOException {
+		Properties properties = LiquibaseRunner.loadProperties();
+		String script = properties.getProperty("script.file");
+
+		if (StringUtils.isEmpty(script)) {
+			Assert.fail("The liquibase upgrade script must be specified. (-Dscript.file=<path to file>)");
+		}
+
+		script = FilenameUtils.getFullPath(script);
+		if (!new File(script).exists()) {
+			Assert.fail("Could not find a liquibase upgrade script at: " + script);
+		}
+
+		try {
+			DatabaseUpdater.executeChangelog(properties.getProperty("script.file"), null);
+
+		} catch (InputRequiredException e) {
+			e.printStackTrace();
+
+			Assert.fail(e.getMessage());
+		} catch (DatabaseUpdateException e) {
+			e.printStackTrace();
+
+			Assert.fail(e.getMessage());
+		}
+	}
+}

--- a/test/src/test/java/org/openmrs/contrib/liquibaserunner/UpgradeScriptTest.java
+++ b/test/src/test/java/org/openmrs/contrib/liquibaserunner/UpgradeScriptTest.java
@@ -2,7 +2,6 @@ package org.openmrs.contrib.liquibaserunner;
 
 
 import junit.framework.Assert;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
@@ -25,13 +24,14 @@ public class UpgradeScriptTest extends BaseModuleContextSensitiveTest {
 			Assert.fail("The liquibase upgrade script must be specified. (-Dscript.file=<path to file>)");
 		}
 
-		script = FilenameUtils.getFullPath(script);
-		if (!new File(script).exists()) {
+		File f = new File(script);
+		script = f.getCanonicalPath();
+		if (!f.exists()) {
 			Assert.fail("Could not find a liquibase upgrade script at: " + script);
 		}
 
 		try {
-			DatabaseUpdater.executeChangelog(properties.getProperty("script.file"), null);
+			DatabaseUpdater.executeChangelog(script, null);
 
 		} catch (InputRequiredException e) {
 			e.printStackTrace();

--- a/test/src/test/resources/liquibaserunner.properties
+++ b/test/src/test/resources/liquibaserunner.properties
@@ -1,5 +1,6 @@
 properties.file=${properties.file}
 mvp.file=${mvp.file}
+script.file=${script.file}
 db.url=${db.url}
 db.user=${db.user}
 db.password=${db.password}


### PR DESCRIPTION
The test can be executed from the command line via:
mvn clean test -Ddb.url="jdbc:mysql://localhost:3306/<database>?autoReconnect=true" -Ddb.user='<user>' -Ddb.password='<pass>' -Dscript.file="<path to script>" -Dopenmrs.version="1.9.0" -Dtest=UpgradeScriptTest -DfailIfNoTests=false
